### PR TITLE
Make it viable to make new maps with a name length more akin to vanilla.

### DIFF
--- a/src/main/java/game/map/config/CreateMapPanel.java
+++ b/src/main/java/game/map/config/CreateMapPanel.java
@@ -50,7 +50,7 @@ public class CreateMapPanel extends JPanel
 		bgField.setBorder(BorderFactory.createCompoundBorder(
 			bgField.getBorder(),
 			BorderFactory.createEmptyBorder(2, 4, 2, 4)));
-		bgField.setDocument(new LimitedLengthDocument(7));
+		bgField.setDocument(new LimitedLengthDocument(8));
 
 		mapNicknameField = new JTextField();
 		mapNicknameField.setBorder(BorderFactory.createCompoundBorder(

--- a/src/main/java/game/map/config/CreateMapPanel.java
+++ b/src/main/java/game/map/config/CreateMapPanel.java
@@ -40,7 +40,7 @@ public class CreateMapPanel extends JPanel
 		mapNameField.setBorder(BorderFactory.createCompoundBorder(
 			mapNameField.getBorder(),
 			BorderFactory.createEmptyBorder(2, 4, 2, 4)));
-		mapNameField.setDocument(new LimitedLengthDocument(7));
+		mapNameField.setDocument(new LimitedLengthDocument(8));
 
 		mapNameField.setText(defaultName);
 


### PR DESCRIPTION
In the past i did this by just editing the MapTable.xml and it had no issues, this is a simple fix so you can just do that from the Editor rather than needing to edit the MapTable.xml

I should add that I am unable to test if this compiles the mod (although i do not see why it shouldn't), due to the bug mentioned earlier in Star Haven.